### PR TITLE
Remove leftover code

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -220,7 +220,6 @@ namespace xpyt
 
     void interpreter::shutdown_request_impl()
     {
-        py::finalize_interpreter();
     }
 
     void interpreter::input_reply_impl(const std::string& /*value*/)


### PR DESCRIPTION
This code is not needed anymore, the `scoped_interpreter` does this already