### PR TITLE
Clean code

### DIFF
--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -26,7 +26,7 @@ namespace nl = nlohmann;
 
 namespace xpyt
 {
-    xcomm::xcomm(py::args /*args*/, py::kwargs kwargs)
+    xcomm::xcomm(const py::args& /*args*/, const py::kwargs& kwargs)
         : m_comm(target(kwargs), id(kwargs))
     {
         m_comm.open(
@@ -55,7 +55,7 @@ namespace xpyt
         return true;
     }
 
-    void xcomm::close(py::args /*args*/, py::kwargs kwargs)
+    void xcomm::close(const py::args& /*args*/, const py::kwargs& kwargs)
     {
         m_comm.close(
             kwargs.attr("get")("metadata", py::dict()),
@@ -64,7 +64,7 @@ namespace xpyt
         );
     }
 
-    void xcomm::send(py::args /*args*/, py::kwargs kwargs)
+    void xcomm::send(const py::args& /*args*/, const py::kwargs& kwargs)
     {
         m_comm.send(
             kwargs.attr("get")("metadata", py::dict()),
@@ -73,23 +73,23 @@ namespace xpyt
         );
     }
 
-    void xcomm::on_msg(python_callback_type callback)
+    void xcomm::on_msg(const python_callback_type& callback)
     {
         m_comm.on_message(cpp_callback(callback));
     }
 
-    void xcomm::on_close(python_callback_type callback)
+    void xcomm::on_close(const python_callback_type& callback)
     {
         m_comm.on_close(cpp_callback(callback));
     }
 
-    xeus::xtarget* xcomm::target(py::kwargs kwargs) const
+    xeus::xtarget* xcomm::target(const py::kwargs& kwargs) const
     {
         std::string target_name = kwargs["target_name"].cast<std::string>();
         return xeus::get_interpreter().comm_manager().target(target_name);
     }
 
-    xeus::xguid xcomm::id(py::kwargs kwargs) const
+    xeus::xguid xcomm::id(const py::kwargs& kwargs) const
     {
         if (py::hasattr(kwargs, "comm_id"))
         {
@@ -102,7 +102,7 @@ namespace xpyt
         }
     }
 
-    auto xcomm::cpp_callback(python_callback_type py_callback) const -> cpp_callback_type
+    auto xcomm::cpp_callback(const python_callback_type& py_callback) const -> cpp_callback_type
     {
         return [this, py_callback](const xeus::xmessage& msg) {
             py_callback(cppmessage_to_pymessage(msg));
@@ -117,9 +117,9 @@ namespace xpyt
     {
     }
 
-    void register_target(py::str target_name, py::object callback)
+    void register_target(const py::str& target_name, const py::object& callback)
     {
-        auto target_callback = [target_name, callback] (xeus::xcomm&& comm, const xeus::xmessage& msg) {
+        auto target_callback = [&callback] (xeus::xcomm&& comm, const xeus::xmessage& msg) {
             callback(xcomm(std::move(comm)), cppmessage_to_pymessage(msg));
         };
 

--- a/src/xcomm.hpp
+++ b/src/xcomm.hpp
@@ -33,7 +33,7 @@ namespace xpyt
         using cpp_callback_type = std::function<void(const xeus::xmessage&)>;
         using zmq_buffers_type = std::vector<zmq::message_t>;
 
-        xcomm(py::args args, py::kwargs kwargs);
+        xcomm(const py::args& args, const py::kwargs& kwargs);
         xcomm(xeus::xcomm&& comm);
         xcomm(xcomm&& comm) = default;
         virtual ~xcomm();
@@ -41,16 +41,16 @@ namespace xpyt
         std::string comm_id() const;
         bool kernel() const;
 
-        void close(py::args args, py::kwargs kwargs);
-        void send(py::args args, py::kwargs kwargs);
-        void on_msg(python_callback_type callback);
-        void on_close(python_callback_type callback);
+        void close(const py::args& args, const py::kwargs& kwargs);
+        void send(const py::args& args, const py::kwargs& kwargs);
+        void on_msg(const python_callback_type& callback);
+        void on_close(const python_callback_type& callback);
 
     private:
 
-        xeus::xtarget* target(py::kwargs kwargs) const;
-        xeus::xguid id(py::kwargs kwargs) const;
-        cpp_callback_type cpp_callback(python_callback_type callback) const;
+        xeus::xtarget* target(const py::kwargs& kwargs) const;
+        xeus::xguid id(const py::kwargs& kwargs) const;
+        cpp_callback_type cpp_callback(const python_callback_type& callback) const;
 
         xeus::xcomm m_comm;
     };

--- a/src/xdisplay.cpp
+++ b/src/xdisplay.cpp
@@ -37,7 +37,7 @@ namespace xpyt
         m_execution_count = execution_count;
     }
 
-    void xdisplayhook::operator()(py::object obj, bool raw = false)
+    void xdisplayhook::operator()(const py::object& obj, bool raw = false) const
     {
         auto& interp = xeus::get_interpreter();
 
@@ -67,7 +67,7 @@ namespace xpyt
         }
     }
 
-    nl::json display_pub_data(py::object obj)
+    nl::json xdisplayhook::display_pub_data(const py::object& obj) const
     {
         py::module py_json = py::module::import("json");
         nl::json pub_data;

--- a/src/xdisplay.hpp
+++ b/src/xdisplay.hpp
@@ -28,14 +28,14 @@ namespace xpyt
         virtual ~xdisplayhook();
 
         void set_execution_count(int execution_count);
-        void operator()(py::object obj, bool raw);
+        void operator()(const py::object& obj, bool raw) const;
 
     private:
 
+        nl::json display_pub_data(const py::object& obj) const;
+
         int m_execution_count;
     };
-
-    nl::json display_pub_data(py::object obj);
 }
 
 #endif

--- a/src/xinput.cpp
+++ b/src/xinput.cpp
@@ -68,10 +68,9 @@ namespace xpyt
          .def("getpass", getpass, py::arg("prompt") = "")
          .def("notimplemented", notimplemented, py::arg("prompt") = "");
 
-        if (PY_MAJOR_VERSION == 2)
-        {
-            m.def("raw_input", input, py::arg("prompt") = "");
-        }
+#if PY_MAJOR_VERSION == 2
+        m.def("raw_input", input, py::arg("prompt") = "");
+#endif
     }
 
     // Implementation of input_redirection
@@ -86,13 +85,12 @@ namespace xpyt
         builtins.attr("input") = allow_stdin ? xeus_python_input.attr("input")
                                              : xeus_python_input.attr("notimplemented");
 
+#if PY_MAJOR_VERSION == 2
         // Forward raw_input()
-        if (PY_MAJOR_VERSION == 2)
-        {
-            m_sys_raw_input = builtins.attr("raw_input");
-            builtins.attr("raw_input") = allow_stdin ? xeus_python_input.attr("raw_input")
-                                                     : xeus_python_input.attr("notimplemented");
-        }
+        m_sys_raw_input = builtins.attr("raw_input");
+        builtins.attr("raw_input") = allow_stdin ? xeus_python_input.attr("raw_input")
+                                                 : xeus_python_input.attr("notimplemented");
+#endif
 
         // Forward getpass()
         py::module getpass = py::module::import("getpass");
@@ -107,11 +105,10 @@ namespace xpyt
         py::module builtins = py::module::import(XPYT_BUILTINS);
         builtins.attr("input") = m_sys_input;
 
+#if PY_MAJOR_VERSION == 2
         // Restore raw_input()
-        if (PY_MAJOR_VERSION == 2)
-        {
-            builtins.attr("raw_input") = m_sys_raw_input;
-        }
+        builtins.attr("raw_input") = m_sys_raw_input;
+#endif
 
         // Restore getpass()
         py::module getpass = py::module::import("getpass");

--- a/src/xinput.cpp
+++ b/src/xinput.cpp
@@ -17,7 +17,7 @@
 #include "pybind11/functional.h"
 
 #include "xinput.hpp"
-#include "xpyt_config.hpp"
+#include "xutils.hpp"
 
 namespace py = pybind11;
 
@@ -76,18 +76,12 @@ namespace xpyt
 
     // Implementation of input_redirection
 
-#if PY_MAJOR_VERSION == 2
-#define XEUS_PYTHON_BUILTINS __builtin__
-#else
-#define XEUS_PYTHON_BUILTINS builtins
-#endif
-
     input_redirection::input_redirection(bool allow_stdin)
     {
         py::module xeus_python_input = py::module::import("xeus_python_input");
 
         // Forward input()
-        py::module builtins = py::module::import(XPYT_STRINGIFY(XEUS_PYTHON_BUILTINS));
+        py::module builtins = py::module::import(XPYT_BUILTINS);
         m_sys_input = builtins.attr("input");
         builtins.attr("input") = allow_stdin ? xeus_python_input.attr("input")
                                              : xeus_python_input.attr("notimplemented");
@@ -110,7 +104,7 @@ namespace xpyt
     input_redirection::~input_redirection()
     {
         // Restore input()
-        py::module builtins = py::module::import(XPYT_STRINGIFY(XEUS_PYTHON_BUILTINS));
+        py::module builtins = py::module::import(XPYT_BUILTINS);
         builtins.attr("input") = m_sys_input;
 
         // Restore raw_input()

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -19,6 +19,7 @@
 #include "pybind11/functional.h"
 
 #include "xpyt_config.hpp"
+#include "xutils.hpp"
 #include "xdisplay.hpp"
 #include "xinput.hpp"
 #include "xinterpreter.hpp"
@@ -122,7 +123,7 @@ namespace xpyt
         {
             // Import AST ans builtins modules
             py::module ast = py::module::import("ast");
-            py::module builtins = py::module::import("builtins");
+            py::module builtins = py::module::import(XPYT_BUILTINS);
 
             // Parse code to AST
             py::object code_ast = ast.attr("parse")(code, "<string>", "exec");

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -48,7 +48,7 @@ namespace xpyt
         return bufferlist;
     }
 
-    std::vector<zmq::message_t> pylist_to_zmq_buffers(py::list bufferlist)
+    std::vector<zmq::message_t> pylist_to_zmq_buffers(const py::list& bufferlist)
     {
         std::vector<zmq::message_t> buffers;
         for (py::handle buffer : bufferlist)
@@ -130,7 +130,7 @@ namespace nlohmann
             }
         }
 
-        json to_json_impl(py::handle obj)
+        json to_json_impl(const py::handle& obj)
         {
             if (obj.is_none())
             {
@@ -155,7 +155,7 @@ namespace nlohmann
             if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj))
             {
                 json out;
-                for (py::handle value: obj)
+                for (const py::handle& value: obj)
                 {
                     out.push_back(to_json_impl(value));
                 }
@@ -164,7 +164,7 @@ namespace nlohmann
             if (py::isinstance<py::dict>(obj))
             {
                 json out;
-                for (py::handle key: obj)
+                for (const py::handle& key: obj)
                 {
                     out[key.cast<std::string>()] = to_json_impl(obj[key]);
                 }
@@ -179,7 +179,7 @@ namespace nlohmann
         return detail::from_json_impl(j);
     }
 
-    void adl_serializer<py::object>::to_json(json& j, py::object obj)
+    void adl_serializer<py::object>::to_json(json& j, const py::object& obj)
     {
         j = detail::to_json_impl(obj);
     }

--- a/src/xutils.hpp
+++ b/src/xutils.hpp
@@ -22,6 +22,12 @@
 namespace py = pybind11;
 namespace nl = nlohmann;
 
+#if PY_MAJOR_VERSION == 2
+    #define XPYT_BUILTINS "__builtin__"
+#else
+    #define XPYT_BUILTINS "builtins"
+#endif
+
 namespace xpyt
 {
     py::list zmq_buffers_to_pylist(const std::vector<zmq::message_t>& buffers);

--- a/src/xutils.hpp
+++ b/src/xutils.hpp
@@ -31,7 +31,7 @@ namespace nl = nlohmann;
 namespace xpyt
 {
     py::list zmq_buffers_to_pylist(const std::vector<zmq::message_t>& buffers);
-    std::vector<zmq::message_t> pylist_to_zmq_buffers(py::list bufferlist);
+    std::vector<zmq::message_t> pylist_to_zmq_buffers(const py::list& bufferlist);
 
     py::object cppmessage_to_pymessage(const xeus::xmessage& msg);
 }
@@ -42,7 +42,7 @@ namespace nlohmann
     struct adl_serializer<py::object>
     {
         static py::object from_json(const json& j);
-        static void to_json(json& j, py::object obj);
+        static void to_json(json& j, const py::object& obj);
     };
 }
 


### PR DESCRIPTION
- Fix a bug in Python 2 with the builtins package (Maybe we should enable CI for Python 2)
- use `const py::object&` instead of `py::object` everywhere in the code, it shouldn't make any difference in terms of performances. But still cleaner.