### PR TITLE
Use protected methods and members

### DIFF
--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -38,7 +38,7 @@ namespace xpyt
         interpreter(int argc, const char* const* argv);
         virtual ~interpreter();
 
-    private:
+    protected:
 
         void configure_impl() override;
 


### PR DESCRIPTION
This allows subclasses to call the xeus-python request implementation
logics, and override of the displayhook if need be.