### PR TITLE
Implemented inspectVariables command

### DIFF
--- a/src/xdebugger.hpp
+++ b/src/xdebugger.hpp
@@ -42,6 +42,7 @@ namespace xpyt
         nl::json dump_cell_request(const nl::json& message);
         nl::json set_breakpoints_request(const nl::json& message);
         nl::json debug_info_request(const nl::json& message);
+        nl::json inspect_variables_request(const nl::json& message);
 
         void start();
         void stop();


### PR DESCRIPTION
Although this is technically working, I prefer to wait for a release of pybind11_json and replace the serialization of `globals` with it.

Actually releasing pybind11_json might take a while, let's merge this PR and update later.