### PR TITLE
Add source request

### DIFF
--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -87,6 +87,10 @@ namespace xpyt
             {
                 reply = set_breakpoints_request(message);
             }
+            else if(message["command"] == "source")
+            {
+                reply = source_request(message);
+            }
             else
             {
                 reply = forward_message(message);
@@ -238,6 +242,50 @@ namespace xpyt
             }}
         };
 
+        return reply;
+    }
+
+    nl::json debugger::source_request(const nl::json& message)
+    {
+        std::string sourcePath;
+        try
+        {
+            sourcePath = message["arguments"]["source"]["path"];
+        }
+        catch(nl::json::type_error& e)
+        {
+            std::clog << e.what() << std::endl;
+        }
+        catch(...)
+        {
+            std::clog << "XEUS-PYTHON: Unknown issue" << std::endl;
+        }
+
+        std::ifstream ifs(sourcePath, std::ios::in);
+        if(!ifs.is_open())
+        {
+            nl::json reply = {
+                {"type", "response"},
+                {"request_seq", message["seq"]},
+                {"success", false},
+                {"command", message["command"]},
+                {"message", "source unavailable"},
+                {"body", {{}}}
+            };
+            return reply;
+        }
+
+        std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+        nl::json reply = {
+            {"type", "response"},
+            {"request_seq", message["seq"]},
+            {"success", true},
+            {"command", message["command"]},
+            {"body", {
+                {"content", content}
+            }}
+        };
         return reply;
     }
 

--- a/src/xdebugger.hpp
+++ b/src/xdebugger.hpp
@@ -43,6 +43,7 @@ namespace xpyt
         nl::json forward_message(const nl::json& message);
         nl::json dump_cell_request(const nl::json& message);
         nl::json set_breakpoints_request(const nl::json& message);
+        nl::json source_request(const nl::json& message);
         nl::json debug_info_request(const nl::json& message);
         nl::json inspect_variables_request(const nl::json& message);
 
@@ -61,7 +62,7 @@ namespace xpyt
         std::set<int> m_stopped_threads;
         std::mutex m_stopped_mutex;
         bool m_is_started;
-        
+
     };
 
     XEUS_PYTHON_API

--- a/test/test_debugger.cpp
+++ b/test/test_debugger.cpp
@@ -239,6 +239,21 @@ nl::json make_dump_cell_request(int seq, const std::string& code)
     return req;
 }
 
+nl::json make_source_request(int seq, const std::string& path)
+{
+    nl::json req = {
+        {"type", "request"},
+        {"seq", seq},
+        {"command", "source"},
+        {"arguments", {
+            {"source", {
+                {"path", path}
+            }}
+        }}
+    };
+    return req;
+}
+
 nl::json make_stepin_request(int seq, int thread_id)
 {
     nl::json req = {
@@ -290,6 +305,7 @@ public:
     bool test_external_set_breakpoints();
     bool test_external_next_continue();
     bool test_set_breakpoints();
+    bool test_source();
     bool test_next_continue();
     bool test_step_in();
     bool test_debug_info();
@@ -401,6 +417,23 @@ bool debugger_client::test_set_breakpoints()
     attach();
     nl::json rep = set_breakpoints();
     return rep["content"]["body"].size() != 0;
+}
+
+bool debugger_client::test_source()
+{
+    attach();
+
+    std::string code = make_code();
+    m_client.send_on_control("debug_request", make_dump_cell_request(4, code));
+    nl::json reply = m_client.receive_on_control();
+    std::string path = reply["content"]["body"]["sourcePath"].get<std::string>();
+
+    m_client.send_on_control("debug_request", make_source_request(5, path));
+    nl::json rep = m_client.receive_on_control();
+
+    nl::json source = rep["content"]["body"]["content"];
+    bool res = source == code + '\n';
+    return res;
 }
 
 void debugger_client::next(int& seq)
@@ -780,6 +813,19 @@ TEST(debugger, set_breakpoints)
     {
         debugger_client deb(context, KERNEL_JSON, "debugger_set_breakpoints.log");
         bool res = deb.test_set_breakpoints();
+        deb.shutdown();
+        std::this_thread::sleep_for(2s);
+        EXPECT_TRUE(res);
+    }
+}
+
+TEST(debugger, source)
+{
+    start_kernel();
+    zmq::context_t context;
+    {
+        debugger_client deb(context, KERNEL_JSON, "debugger_source.log");
+        bool res = deb.test_source();
         deb.shutdown();
         std::this_thread::sleep_for(2s);
         EXPECT_TRUE(res);


### PR DESCRIPTION
The idea is to implement the `source` request in `xeus-python`, so we are able to retrieve the source code for a give `source.path`.

DAP: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Source

Related:

- https://github.com/jupyterlab/debugger/pull/170
- https://github.com/jupyterlab/debugger/issues/169